### PR TITLE
Feature/styling challenges page

### DIFF
--- a/frontend-runitup/src/Components/Recommendation/ChallengeCard.jsx
+++ b/frontend-runitup/src/Components/Recommendation/ChallengeCard.jsx
@@ -1,8 +1,15 @@
 import React from "react";
 import { Card, Progress, Button, Typography } from "antd";
-import { CheckOutlined, CloseOutlined } from "@ant-design/icons";
+import {
+  CheckOutlined,
+  CloseOutlined,
+  RunningOutlined,
+  FireOutlined,
+  RiseOutlined,
+} from "@ant-design/icons";
+import "../../styles/ChallengeCard.css";
 
-const { Text } = Typography;
+const { Text, Title } = Typography;
 
 const ChallengeCard = ({ challenge, onUpdate }) => {
   const progress = (challenge.currentProgress / challenge.target) * 100;
@@ -16,9 +23,27 @@ const ChallengeCard = ({ challenge, onUpdate }) => {
     return `${hoursLeft}h ${minutesLeft}m`;
   };
 
+  const getIcon = () => {
+    switch (challenge.type) {
+      case "distance":
+        return <RunningOutlined />;
+      case "calories":
+        return <FireOutlined />;
+      case "elevation":
+        return <RiseOutlined />;
+      default:
+        return null;
+    }
+  };
+
   return (
     <Card
-      title={challenge.description}
+      className={`challenge-card ${challenge.status}`}
+      title={
+        <Title level={4}>
+          {getIcon()} {challenge.description}
+        </Title>
+      }
       extra={
         challenge.status === "completed" ? (
           <CheckOutlined style={{ color: "green" }} />
@@ -36,14 +61,23 @@ const ChallengeCard = ({ challenge, onUpdate }) => {
             ? "exception"
             : "active"
         }
+        strokeColor={{
+          "0%": "#108ee9",
+          "100%": "#87d068",
+        }}
       />
-      <Text>
+      <Text className="progress-text">
         Progress: {challenge.currentProgress.toFixed(2)} / {challenge.target}
       </Text>
       <br />
-      {challenge.status === "active" && <Text>Time left: {getTimeLeft()}</Text>}
+      {challenge.status === "active" && (
+        <Text className="time-left">Time left: {getTimeLeft()}</Text>
+      )}
       {challenge.status === "active" && progress >= 100 && (
-        <Button onClick={() => onUpdate(challenge.id, "completed")}>
+        <Button
+          onClick={() => onUpdate(challenge.id, "completed")}
+          className="complete-button"
+        >
           Mark as Completed
         </Button>
       )}

--- a/frontend-runitup/src/Components/Recommendation/ChallengeCard.jsx
+++ b/frontend-runitup/src/Components/Recommendation/ChallengeCard.jsx
@@ -53,7 +53,7 @@ const ChallengeCard = ({ challenge, onUpdate }) => {
       }
     >
       <Progress
-        percent={Math.min(progress, 100)}
+        percent={Math.min(progress, 100).toFixed(2)}
         status={
           challenge.status === "completed"
             ? "success"

--- a/frontend-runitup/src/Components/Recommendation/ChallengeCard.jsx
+++ b/frontend-runitup/src/Components/Recommendation/ChallengeCard.jsx
@@ -3,9 +3,9 @@ import { Card, Progress, Button, Typography } from "antd";
 import {
   CheckOutlined,
   CloseOutlined,
-  RunningOutlined,
+  DashboardOutlined,
   FireOutlined,
-  RiseOutlined,
+  AreaChartOutlined,
 } from "@ant-design/icons";
 import "../../styles/ChallengeCard.css";
 
@@ -26,11 +26,11 @@ const ChallengeCard = ({ challenge, onUpdate }) => {
   const getIcon = () => {
     switch (challenge.type) {
       case "distance":
-        return <RunningOutlined />;
+        return <DashboardOutlined />; // Using DashboardOutlined for distance
       case "calories":
         return <FireOutlined />;
       case "elevation":
-        return <RiseOutlined />;
+        return <AreaChartOutlined />; // Using AreaChartOutlined for elevation
       default:
         return null;
     }

--- a/frontend-runitup/src/Components/Recommendation/PastChallenges.jsx
+++ b/frontend-runitup/src/Components/Recommendation/PastChallenges.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { List, Typography, Empty } from "antd";
 import ChallengeCard from "./ChallengeCard";
+import "../../styles/PastChallenges.css";
 
 const { Title } = Typography;
 
@@ -10,9 +11,9 @@ const PastChallenges = ({ challenges }) => {
   }
 
   return (
-    <div>
+    <div className="past-challenges">
       <List
-        grid={{ gutter: 16, column: 3 }}
+        grid={{ gutter: 16, xs: 1, sm: 2, md: 3, lg: 3, xl: 3, xxl: 3 }}
         dataSource={challenges}
         renderItem={(challenge) => (
           <List.Item>

--- a/frontend-runitup/src/Components/Recommendation/PastChallenges.jsx
+++ b/frontend-runitup/src/Components/Recommendation/PastChallenges.jsx
@@ -1,26 +1,50 @@
-import React from "react";
-import { List, Typography, Empty } from "antd";
+import React, { useState } from "react";
+import { List, Typography, Empty, Pagination } from "antd";
 import ChallengeCard from "./ChallengeCard";
 import "../../styles/PastChallenges.css";
 
 const { Title } = Typography;
 
 const PastChallenges = ({ challenges }) => {
+  const [currentPage, setCurrentPage] = useState(1);
+  const challengesPerPage = 9;
+
   if (!challenges || challenges.length === 0) {
     return <Empty description="No past challenges found" />;
   }
+
+  const indexOfLastChallenge = currentPage * challengesPerPage;
+  const indexOfFirstChallenge = indexOfLastChallenge - challengesPerPage;
+  const currentChallenges = challenges.slice(
+    indexOfFirstChallenge,
+    indexOfLastChallenge
+  );
+
+  const handlePageChange = (page) => {
+    setCurrentPage(page);
+  };
 
   return (
     <div className="past-challenges">
       <List
         grid={{ gutter: 16, xs: 1, sm: 2, md: 3, lg: 3, xl: 3, xxl: 3 }}
-        dataSource={challenges}
+        dataSource={currentChallenges}
         renderItem={(challenge) => (
           <List.Item>
             <ChallengeCard challenge={challenge} isPast={true} />
           </List.Item>
         )}
       />
+      <div className="pagination-container">
+        <Pagination
+          current={currentPage}
+          total={challenges.length}
+          pageSize={challengesPerPage}
+          onChange={handlePageChange}
+          showSizeChanger={false}
+          showQuickJumper={false}
+        />
+      </div>
     </div>
   );
 };

--- a/frontend-runitup/src/Components/Recommendation/RecommendationPage.jsx
+++ b/frontend-runitup/src/Components/Recommendation/RecommendationPage.jsx
@@ -3,11 +3,11 @@ import { Layout, Typography, Tabs, message, Spin, Empty } from "antd";
 import { getHeaders } from "../../utils/apiConfig";
 import ChallengeCard from "./ChallengeCard";
 import PastChallenges from "./PastChallenges";
+import "../../styles/RecommendationPage.css";
 
 const { Content } = Layout;
 const { Title, Text } = Typography;
 const { TabPane } = Tabs;
-
 const RecommendationPage = () => {
   const [activeChallenges, setActiveChallenges] = useState([]);
   const [pastChallenges, setPastChallenges] = useState([]);
@@ -107,11 +107,12 @@ const RecommendationPage = () => {
   };
 
   return (
-    <Layout style={{ padding: "50px 0 0 0" }}>
-      <Content style={{ padding: "50px" }}>
+    <Layout className="recommendation-page">
+      <Content className="recommendation-content">
+        <Title level={2}>Challenges</Title>
         <Tabs defaultActiveKey="1">
           <TabPane tab="Current Challenges" key="1">
-            {renderChallenges()}
+            <div className="challenges-grid">{renderChallenges()}</div>
           </TabPane>
           <TabPane tab="Past Challenges" key="2">
             <PastChallenges challenges={pastChallenges} />

--- a/frontend-runitup/src/Components/Recommendation/RecommendationPage.jsx
+++ b/frontend-runitup/src/Components/Recommendation/RecommendationPage.jsx
@@ -109,7 +109,6 @@ const RecommendationPage = () => {
   return (
     <Layout className="recommendation-page">
       <Content className="recommendation-content">
-        <Title level={2}>Challenges</Title>
         <Tabs defaultActiveKey="1">
           <TabPane tab="Current Challenges" key="1">
             <div className="challenges-grid">{renderChallenges()}</div>

--- a/frontend-runitup/src/styles/ChallengeCard.css
+++ b/frontend-runitup/src/styles/ChallengeCard.css
@@ -1,0 +1,52 @@
+.challenge-card {
+  margin-bottom: 16px;
+  transition: all 0.3s;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.1);
+}
+
+.challenge-card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+}
+
+.challenge-card .ant-card-head-title {
+  display: flex;
+  align-items: center;
+}
+
+.challenge-card .ant-card-head-title .anticon {
+  margin-right: 8px;
+  font-size: 20px;
+}
+
+.challenge-card.completed {
+  border-color: #52c41a;
+}
+
+.challenge-card.failed {
+  border-color: #f5222d;
+}
+
+.challenge-card .ant-progress-bg {
+  border-radius: 4px;
+}
+
+.challenge-card .progress-text,
+.challenge-card .time-left {
+  display: block;
+  margin-top: 8px;
+}
+
+.challenge-card .complete-button {
+  margin-top: 16px;
+}
+
+@keyframes celebrate {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.05); }
+  100% { transform: scale(1); }
+}
+
+.challenge-card.completed {
+  animation: celebrate 0.5s ease-in-out;
+}

--- a/frontend-runitup/src/styles/PastChallenges.css
+++ b/frontend-runitup/src/styles/PastChallenges.css
@@ -1,3 +1,14 @@
-.past-challenges {
+.pagination-container {
+  display: flex;
+  justify-content: center;
   margin-top: 24px;
+}
+
+.ant-pagination-item-active {
+  background-color: #1890ff;
+  border-color: #1890ff;
+}
+
+.ant-pagination-item-active a {
+  color: #ffffff;
 }

--- a/frontend-runitup/src/styles/PastChallenges.css
+++ b/frontend-runitup/src/styles/PastChallenges.css
@@ -1,0 +1,3 @@
+.past-challenges {
+  margin-top: 24px;
+}

--- a/frontend-runitup/src/styles/RecommendationPage.css
+++ b/frontend-runitup/src/styles/RecommendationPage.css
@@ -1,78 +1,23 @@
-
 .recommendation-page {
   background-color: #f0f2f5;
-  min-height: calc(100vh - 64px);
-  padding-top: 64px;
 }
 
 .recommendation-content {
-  max-width: 1200px;
-  margin: 0 auto;
   padding: 24px;
+  max-width: 2000px;
 }
 
-.challenge-section {
-  margin-bottom: 48px;
-}
-
-.challenge-section-title {
-  color: #1890ff;
-  margin-bottom: 24px;
-  text-align: center;
-}
-
-.challenge-list {
+.challenges-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-  gap: 24px;
+  gap: 16px;
 }
 
-.challenge-card {
-  background-color: #ffffff;
-  border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-  transition: all 0.3s ease;
-}
+@media (max-width: 768px) {
+  .recommendation-content {
+    padding: 16px;
+  }
 
-.challenge-card:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
-}
-
-.challenge-card .ant-card-head {
-  background-color: #1890ff;
-  color: #ffffff;
-  border-top-left-radius: 8px;
-  border-top-right-radius: 8px;
-}
-
-.challenge-card .ant-card-head-title {
-  font-weight: 600;
-}
-
-.challenge-card .ant-progress {
-  margin-bottom: 16px;
-}
-
-.challenge-info {
-  margin-bottom: 8px;
-  color: #595959;
-}
-
-.challenge-complete-button {
-  width: 100%;
-  margin-top: 16px;
-}
-
-.completed-challenge-card {
-  opacity: 0.7;
-}
-
-.completed-challenge-card .ant-card-head {
-  background-color: #52c41a;
-}
-
-.trophy-icon {
-  font-size: 24px;
-  color: gold;
+  .challenges-grid {
+    grid-template-columns: 1fr;
+  }
 }

--- a/frontend-runitup/src/styles/RecommendationPage.css
+++ b/frontend-runitup/src/styles/RecommendationPage.css
@@ -1,5 +1,6 @@
 .recommendation-page {
   background-color: #f0f2f5;
+  padding-top: 60px;
 }
 
 .recommendation-content {


### PR DESCRIPTION
## Description

what this pull request is doing:
I improved the frontend design for the challenges page. For the current challenges, I implemented a gradient color to go from blue to green as a user gets closer to completing the challenge for the progress bar. In addition, in the past cahllenges tab, I added pagination to easier see all the past challenges. 

The reason i chose to go from blue to green was because the original plan was to start at red and progressing move to green. I researched some color physocology, which made me realize that starting at red could discourage a user. This is why i decided to move to blue.

## Milestones
<the milestones or stories/features that this works towards>

## Resources
 - https://supercharge.design/blog/color-psychology-in-ux-design

## Test Plan
![image](https://github.com/user-attachments/assets/30274324-c8bc-4a39-beb2-065abb55194c)

