### PR TITLE
Feature/updating profile page

### DIFF
--- a/frontend-runitup/src/Components/Profile/ProfilePage.jsx
+++ b/frontend-runitup/src/Components/Profile/ProfilePage.jsx
@@ -83,9 +83,9 @@ function ProfilePage({ user, onProfileUpdate }) {
   };
 
   return (
-    <Layout style={{ padding: "100px 0 0 0" }} className="profile-page">
+    <Layout className="profile-page">
       <Content className="profile-content">
-        <Title level={2} className="page-title">
+        <Title level={1} className="page-title">
           {user.name}'s Profile
         </Title>
         <Text type="secondary" className="page-subtitle">
@@ -99,8 +99,8 @@ function ProfilePage({ user, onProfileUpdate }) {
             layout="vertical"
             className="profile-form"
           >
-            <Row gutter={24}>
-              <Col xs={24} sm={12}>
+            <Row gutter={[24, 24]}>
+              <Col xs={24} md={12}>
                 <Card title="Personal Information" className="info-card">
                   <Form.Item
                     name="age"
@@ -109,7 +109,7 @@ function ProfilePage({ user, onProfileUpdate }) {
                       { required: true, message: "Please input your age!" },
                     ]}
                   >
-                    <InputNumber min={1} max={120} prefix={<UserOutlined />} />
+                    <InputNumber min={1} max={120} className="full-width" />
                   </Form.Item>
                   <Form.Item
                     name="gender"
@@ -137,11 +137,7 @@ function ProfilePage({ user, onProfileUpdate }) {
                       { required: true, message: "Please input your weight!" },
                     ]}
                   >
-                    <InputNumber
-                      min={1}
-                      max={300}
-                      prefix={<DashboardOutlined />}
-                    />
+                    <InputNumber min={1} max={1000} className="full-width" />
                   </Form.Item>
                   <Form.Item
                     name="height"
@@ -152,13 +148,14 @@ function ProfilePage({ user, onProfileUpdate }) {
                   >
                     <InputNumber
                       min={1}
-                      max={300}
-                      prefix={<DashboardOutlined />}
+                      max={10}
+                      step={0.01}
+                      className="full-width"
                     />
                   </Form.Item>
                 </Card>
               </Col>
-              <Col xs={24} sm={12}>
+              <Col xs={24} md={12}>
                 <Card title="Running Profile" className="info-card">
                   <Form.Item
                     name="fitnessLevel"

--- a/frontend-runitup/src/Components/Profile/ProfilePage.jsx
+++ b/frontend-runitup/src/Components/Profile/ProfilePage.jsx
@@ -12,6 +12,7 @@ import {
   Row,
   Col,
   Spin,
+  Modal,
 } from "antd";
 import {
   UserOutlined,
@@ -21,6 +22,8 @@ import {
   ThunderboltOutlined,
   EnvironmentOutlined,
   HeartOutlined,
+  EditOutlined,
+  SaveOutlined,
 } from "@ant-design/icons";
 import { getHeaders } from "../../utils/apiConfig";
 import "../../styles/ProfilePage.css";
@@ -32,6 +35,9 @@ const { Title, Text } = Typography;
 function ProfilePage({ user, onProfileUpdate }) {
   const [form] = Form.useForm();
   const [loading, setLoading] = useState(true);
+  const [editMode, setEditMode] = useState(false);
+  const [confirmModalVisible, setConfirmModalVisible] = useState(false);
+  const [updatedValues, setUpdatedValues] = useState(null);
 
   useEffect(() => {
     fetchProfile();
@@ -57,14 +63,19 @@ function ProfilePage({ user, onProfileUpdate }) {
     }
   };
 
-  const onFinish = async (values) => {
+  const onFinish = (values) => {
+    setUpdatedValues(values);
+    setConfirmModalVisible(true);
+  };
+
+  const handleConfirmUpdate = async () => {
     try {
       const response = await fetch(
         `${import.meta.env.VITE_POST_ADDRESS}/profile`,
         {
           method: "PUT",
           headers: getHeaders(),
-          body: JSON.stringify(values),
+          body: JSON.stringify(updatedValues),
         }
       );
 
@@ -77,9 +88,15 @@ function ProfilePage({ user, onProfileUpdate }) {
       if (onProfileUpdate) {
         onProfileUpdate(data);
       }
+      setEditMode(false);
+      setConfirmModalVisible(false);
     } catch (error) {
       message.error(`Error updating profile: ${error.message}`);
     }
+  };
+
+  const toggleEditMode = () => {
+    setEditMode(!editMode);
   };
 
   return (
@@ -92,166 +109,158 @@ function ProfilePage({ user, onProfileUpdate }) {
           View and update your information
         </Text>
 
-        <Spin spinning={loading}>
-          <Form
-            form={form}
-            onFinish={onFinish}
-            layout="vertical"
-            className="profile-form"
-          >
-            <Row gutter={[24, 24]}>
-              <Col xs={24} md={12}>
-                <Card title="Personal Information" className="info-card">
-                  <Form.Item
-                    name="age"
-                    label="Age"
-                    rules={[
-                      { required: true, message: "Please input your age!" },
-                    ]}
+        <Card className="profile-card">
+          <Spin spinning={loading}>
+            <Form
+              form={form}
+              onFinish={onFinish}
+              layout="vertical"
+              className="profile-form"
+            >
+              <Row gutter={[24, 24]}>
+                <Col xs={24} md={12}>
+                  <Card title="Personal Information" className="info-card">
+                    <Form.Item name="age" label="Age">
+                      <InputNumber
+                        disabled={!editMode}
+                        className="full-width"
+                      />
+                    </Form.Item>
+                    <Form.Item name="gender" label="Gender">
+                      <Select disabled={!editMode}>
+                        <Option value="male">
+                          <ManOutlined /> Male
+                        </Option>
+                        <Option value="female">
+                          <WomanOutlined /> Female
+                        </Option>
+                        <Option value="other">
+                          <UserOutlined /> Other
+                        </Option>
+                      </Select>
+                    </Form.Item>
+                    <Form.Item name="weight" label="Weight (lbs)">
+                      <InputNumber
+                        disabled={!editMode}
+                        className="full-width"
+                      />
+                    </Form.Item>
+                    <Form.Item name="height" label="Height (ft.in)">
+                      <InputNumber
+                        disabled={!editMode}
+                        step={0.01}
+                        className="full-width"
+                      />
+                    </Form.Item>
+                  </Card>
+                </Col>
+                <Col xs={24} md={12}>
+                  <Card title="Running Profile" className="info-card">
+                    <Form.Item name="fitnessLevel" label="Fitness Level">
+                      <Select disabled={!editMode}>
+                        <Option value="beginner">
+                          <ThunderboltOutlined /> Beginner
+                        </Option>
+                        <Option value="intermediate">
+                          <ThunderboltOutlined /> Intermediate
+                        </Option>
+                        <Option value="advanced">
+                          <ThunderboltOutlined /> Advanced
+                        </Option>
+                      </Select>
+                    </Form.Item>
+                    <Form.Item
+                      name="runningExperience"
+                      label="Running Experience"
+                    >
+                      <Select disabled={!editMode}>
+                        <Option value="novice">
+                          <UserOutlined /> Novice
+                        </Option>
+                        <Option value="recreational">
+                          <UserOutlined /> Recreational
+                        </Option>
+                        <Option value="competitive">
+                          <UserOutlined /> Competitive
+                        </Option>
+                      </Select>
+                    </Form.Item>
+                    <Form.Item
+                      name="preferredTerrains"
+                      label="Preferred Terrains"
+                    >
+                      <Select mode="multiple" disabled={!editMode}>
+                        <Option value="road">
+                          <EnvironmentOutlined /> Road
+                        </Option>
+                        <Option value="trail">
+                          <EnvironmentOutlined /> Trail
+                        </Option>
+                        <Option value="track">
+                          <EnvironmentOutlined /> Track
+                        </Option>
+                      </Select>
+                    </Form.Item>
+                    <Form.Item
+                      name="healthConditions"
+                      label="Health Conditions"
+                    >
+                      <Select mode="multiple" disabled={!editMode}>
+                        <Option value="asthma">
+                          <HeartOutlined /> Asthma
+                        </Option>
+                        <Option value="kneeIssues">
+                          <HeartOutlined /> Knee Issues
+                        </Option>
+                        <Option value="backPain">
+                          <HeartOutlined /> Back Pain
+                        </Option>
+                      </Select>
+                    </Form.Item>
+                  </Card>
+                </Col>
+              </Row>
+              {editMode ? (
+                <Form.Item>
+                  <Button
+                    type="primary"
+                    htmlType="submit"
+                    size="large"
+                    block
+                    className="update-button"
+                    icon={<SaveOutlined />}
                   >
-                    <InputNumber min={1} max={120} className="full-width" />
-                  </Form.Item>
-                  <Form.Item
-                    name="gender"
-                    label="Gender"
-                    rules={[
-                      { required: true, message: "Please select your gender!" },
-                    ]}
-                  >
-                    <Select>
-                      <Option value="male">
-                        <ManOutlined /> Male
-                      </Option>
-                      <Option value="female">
-                        <WomanOutlined /> Female
-                      </Option>
-                      <Option value="other">
-                        <UserOutlined /> Other
-                      </Option>
-                    </Select>
-                  </Form.Item>
-                  <Form.Item
-                    name="weight"
-                    label="Weight (lbs)"
-                    rules={[
-                      { required: true, message: "Please input your weight!" },
-                    ]}
-                  >
-                    <InputNumber min={1} max={1000} className="full-width" />
-                  </Form.Item>
-                  <Form.Item
-                    name="height"
-                    label="Height (ft.in)"
-                    rules={[
-                      { required: true, message: "Please input your height!" },
-                    ]}
-                  >
-                    <InputNumber
-                      min={1}
-                      max={10}
-                      step={0.01}
-                      className="full-width"
-                    />
-                  </Form.Item>
-                </Card>
-              </Col>
-              <Col xs={24} md={12}>
-                <Card title="Running Profile" className="info-card">
-                  <Form.Item
-                    name="fitnessLevel"
-                    label="Fitness Level"
-                    rules={[
-                      {
-                        required: true,
-                        message: "Please select your fitness level!",
-                      },
-                    ]}
-                  >
-                    <Select>
-                      <Option value="beginner">
-                        <ThunderboltOutlined /> Beginner
-                      </Option>
-                      <Option value="intermediate">
-                        <ThunderboltOutlined /> Intermediate
-                      </Option>
-                      <Option value="advanced">
-                        <ThunderboltOutlined /> Advanced
-                      </Option>
-                    </Select>
-                  </Form.Item>
-                  <Form.Item
-                    name="runningExperience"
-                    label="Running Experience"
-                    rules={[
-                      {
-                        required: true,
-                        message: "Please select your running experience!",
-                      },
-                    ]}
-                  >
-                    <Select>
-                      <Option value="novice">
-                        <UserOutlined /> Novice
-                      </Option>
-                      <Option value="recreational">
-                        <UserOutlined /> Recreational
-                      </Option>
-                      <Option value="competitive">
-                        <UserOutlined /> Competitive
-                      </Option>
-                    </Select>
-                  </Form.Item>
-                  <Form.Item
-                    name="preferredTerrains"
-                    label="Preferred Terrains"
-                    rules={[
-                      {
-                        required: true,
-                        message: "Please select your preferred terrains!",
-                      },
-                    ]}
-                  >
-                    <Select mode="multiple">
-                      <Option value="road">
-                        <EnvironmentOutlined /> Road
-                      </Option>
-                      <Option value="trail">
-                        <EnvironmentOutlined /> Trail
-                      </Option>
-                      <Option value="track">
-                        <EnvironmentOutlined /> Track
-                      </Option>
-                    </Select>
-                  </Form.Item>
-                  <Form.Item name="healthConditions" label="Health Conditions">
-                    <Select mode="multiple">
-                      <Option value="asthma">
-                        <HeartOutlined /> Asthma
-                      </Option>
-                      <Option value="kneeIssues">
-                        <HeartOutlined /> Knee Issues
-                      </Option>
-                      <Option value="backPain">
-                        <HeartOutlined /> Back Pain
-                      </Option>
-                    </Select>
-                  </Form.Item>
-                </Card>
-              </Col>
-            </Row>
-            <Form.Item>
-              <Button
-                type="primary"
-                htmlType="submit"
-                size="large"
-                block
-                className="update-button"
-              >
-                Update Profile
-              </Button>
-            </Form.Item>
-          </Form>
-        </Spin>
+                    Save Changes
+                  </Button>
+                </Form.Item>
+              ) : (
+                <Button
+                  type="primary"
+                  size="large"
+                  block
+                  className="edit-button"
+                  onClick={toggleEditMode}
+                  icon={<EditOutlined />}
+                >
+                  Edit Your Profile
+                </Button>
+              )}
+            </Form>
+          </Spin>
+        </Card>
+
+        <Modal
+          title="Confirm Profile Update"
+          visible={confirmModalVisible}
+          onOk={handleConfirmUpdate}
+          onCancel={() => setConfirmModalVisible(false)}
+          okText="Confirm"
+          cancelText="Cancel"
+        >
+          <p>
+            Are you sure you want to update your profile with these changes?
+          </p>
+        </Modal>
       </Content>
     </Layout>
   );

--- a/frontend-runitup/src/Components/Profile/ProfilePage.jsx
+++ b/frontend-runitup/src/Components/Profile/ProfilePage.jsx
@@ -23,7 +23,6 @@ import {
   HeartOutlined,
 } from "@ant-design/icons";
 import { getHeaders } from "../../utils/apiConfig";
-import UserActivities from "./UserActivites";
 import "../../styles/ProfilePage.css";
 
 const { Content } = Layout;
@@ -255,9 +254,6 @@ function ProfilePage({ user, onProfileUpdate }) {
               </Button>
             </Form.Item>
           </Form>
-          <Col xs={24} lg={12}>
-            <UserActivities />
-          </Col>
         </Spin>
       </Content>
     </Layout>

--- a/frontend-runitup/src/styles/ProfilePage.css
+++ b/frontend-runitup/src/styles/ProfilePage.css
@@ -1,7 +1,7 @@
 .profile-page {
   min-height: calc(100vh - 64px);
   padding: 40px;
-  background: #f0f2f5;
+  background: linear-gradient(135deg, #f0f2f5 0%, #e6f7ff 100%);
 }
 
 .profile-content {
@@ -10,36 +10,55 @@
 }
 
 .page-title {
+  font-size: 3rem;
   text-align: center;
   color: #1890ff;
-  margin-bottom: 8px;
+  margin-bottom: 0.5rem;
+  text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 .page-subtitle {
   display: block;
   text-align: center;
-  margin-bottom: 32px;
+  margin-bottom: 3rem;
+  font-size: 1.2rem;
+  color: #8c8c8c;
 }
 
 .profile-form {
   background: white;
-  padding: 24px;
-  border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  padding: 2rem;
+  border-radius: 16px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
 }
 
 .info-card {
   height: 100%;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.09);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+  border-radius: 12px;
+  transition: all 0.3s ease;
+}
+
+.info-card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
 }
 
 .info-card .ant-card-head {
-  background: #1890ff;
+  background: linear-gradient(135deg, #1890ff 0%, #096dd9 100%);
   color: white;
+  border-top-left-radius: 12px;
+  border-top-right-radius: 12px;
+  padding: 16px 24px;
+}
+
+.info-card .ant-card-head-title {
+  font-size: 1.4rem;
 }
 
 .ant-form-item-label > label {
   font-weight: 600;
+  font-size: 1rem;
 }
 
 .ant-input-number-prefix,
@@ -49,14 +68,15 @@
 }
 
 .update-button {
-  margin-top: 24px;
+  margin-top: 2rem;
   height: 50px;
-  font-size: 18px;
+  font-size: 1.2rem;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 1px;
   background: linear-gradient(135deg, #1890ff 0%, #52c41a 100%);
   border: none;
+  border-radius: 25px;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
   transition: all 0.3s ease;
 }
@@ -64,7 +84,7 @@
 .update-button:hover,
 .update-button:focus {
   background: linear-gradient(135deg, #40a9ff 0%, #73d13d 100%);
-  box-shadow: 0 6px 8px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
   transform: translateY(-2px);
 }
 
@@ -73,16 +93,29 @@
   border-color: #91d5ff;
 }
 
+.full-width {
+  width: 100%;
+}
+
 @media (max-width: 768px) {
   .profile-page {
     padding: 20px;
   }
 
   .profile-form {
-    padding: 16px;
+    padding: 1.5rem;
   }
 
   .info-card {
-    margin-bottom: 16px;
+    margin-bottom: 1.5rem;
+  }
+
+  .page-title {
+    font-size: 2.5rem;
+  }
+
+  .page-subtitle {
+    font-size: 1rem;
+    margin-bottom: 2rem;
   }
 }

--- a/frontend-runitup/src/styles/ProfilePage.css
+++ b/frontend-runitup/src/styles/ProfilePage.css
@@ -1,11 +1,12 @@
 .profile-page {
   min-height: calc(100vh - 64px);
   padding: 40px;
+  padding-top: 80px;
   background: linear-gradient(135deg, #f0f2f5 0%, #e6f7ff 100%);
 }
 
 .profile-content {
-  max-width: 1200px;
+  max-width: 1400px;
   margin: 0 auto;
 }
 
@@ -20,16 +21,20 @@
 .page-subtitle {
   display: block;
   text-align: center;
-  margin-bottom: 3rem;
+  margin-bottom: 2rem;
   font-size: 1.2rem;
   color: #8c8c8c;
 }
 
-.profile-form {
+.profile-card {
   background: white;
-  padding: 2rem;
   border-radius: 16px;
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+  padding: 2rem;
+}
+
+.profile-form {
+  width: 100%;
 }
 
 .info-card {
@@ -61,40 +66,42 @@
   font-size: 1rem;
 }
 
-.ant-input-number-prefix,
-.ant-select-selection-item .anticon {
-  margin-right: 8px;
-  color: #1890ff;
+.ant-input-number-disabled,
+.ant-select-disabled .ant-select-selector {
+  color: rgba(0, 0, 0, 0.65) !important;
+  background-color: #f5f5f5 !important;
 }
 
-.update-button {
+.full-width {
+  width: 100%;
+}
+
+.update-button,
+.edit-button {
   margin-top: 2rem;
   height: 50px;
   font-size: 1.2rem;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 1px;
-  background: linear-gradient(135deg, #1890ff 0%, #52c41a 100%);
   border: none;
   border-radius: 25px;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
   transition: all 0.3s ease;
 }
 
+.update-button {
+  background: linear-gradient(135deg, #52c41a 0%, #1890ff 100%);
+}
+
+.edit-button {
+  background: linear-gradient(135deg, #1890ff 0%, #096dd9 100%);
+}
+
 .update-button:hover,
-.update-button:focus {
-  background: linear-gradient(135deg, #40a9ff 0%, #73d13d 100%);
+.edit-button:hover {
   box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
   transform: translateY(-2px);
-}
-
-.ant-select-multiple .ant-select-selection-item {
-  background-color: #e6f7ff;
-  border-color: #91d5ff;
-}
-
-.full-width {
-  width: 100%;
 }
 
 @media (max-width: 768px) {
@@ -102,7 +109,7 @@
     padding: 20px;
   }
 
-  .profile-form {
+  .profile-card {
     padding: 1.5rem;
   }
 
@@ -116,6 +123,6 @@
 
   .page-subtitle {
     font-size: 1rem;
-    margin-bottom: 2rem;
+    margin-bottom: 1.5rem;
   }
 }


### PR DESCRIPTION
## Description

<what this pull request is doing>
This pull request changes the user experience for the user profile page. Now a user can see their info, but the items are disabled for changed until a user clicks edit profile. There they can update and change as they like and then save the changes in which a modal opens to confirm.

## Milestones
Styling

## Test Plan

Disabled button:
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/d5e5d31e-4c86-4595-be0f-19e956939198">

after clicking edit profile:
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/869870c5-1665-4771-96f6-cd2af7db1082">

confirming after clicking save button:
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/9aea66f9-33eb-4c0d-97d3-867f6c94b14a">
